### PR TITLE
Update schedule for 2023/10/03 with correct link

### DIFF
--- a/docs/courses/monarch-obo-training.md
+++ b/docs/courses/monarch-obo-training.md
@@ -29,7 +29,7 @@ _Note: this is tentative and subject to change_
 | Date | Lesson | Notes | Recordings |
 | --- | --- | --- | --- |
 | 2023/10/17 | Using ontologies for data annotation and consequences of ontology development | Sabrina Toro | |
-| 2023/10/03 | [Units modelling in and around OBO](https://github.com/OBOAcademy/obook/issues/421) | James Overton | |
+| 2023/10/03 | [Units modeling in and around OBO](https://oboacademy.github.io/obook/tutorial/units/) | James Overton | |
 | 2023/09/19 | [Improving ontology interoperability with Biomappings](https://docs.google.com/presentation/d/1s9QNQQoRuQUWWJoIJklMHrqPowvBKU4Y638w54xP1t0/edit) | Charlie Hoyt | |
 | 2023/09/05 | [Modern prefix management with Bioregistry and `curies`](https://docs.google.com/presentation/d/1Hyi9t_wwoMAFskWtDBMHGpAw7ZwTQx-3RKrFdTFYB88/edit) | Charlie Hoyt | [Here](https://youtu.be/WTTHCZW4ubs?feature=shared) |
 | 2023/08/22 | [How to determine if two entities are the same?](../howto/are-two-entities-the-same) | Nico | [Here](https://youtu.be/v5hjLgr54Zs?feature=shared) |


### PR DESCRIPTION
Updated the OBO academy schedule with the correct link to OBOOK page https://oboacademy.github.io/obook/tutorial/units/ for **Units modeling in and around OBO** being presented on 2023/10/03