### PR TITLE
Create AI4Curators.md

### DIFF
--- a/docs/AI4Curators.md
+++ b/docs/AI4Curators.md
@@ -1,0 +1,3 @@
+# AI for Curation and Ontolgy Development
+
+For curators and ontology develpers interseted in the Monarch Initiative's AI4Curators documentation, go here: https://ai4curation.io/aidocs/


### PR DESCRIPTION
Adding a very brief page on the main OBOOK site that links out to https://ai4curation.io/aidocs/ so the community can easily find it if they are used to going to OBOOK for tutorials.