### PR TITLE
fixed npm command to install Claude Code

### DIFF
--- a/docs/tutorial/claude-code-getting-started.md
+++ b/docs/tutorial/claude-code-getting-started.md
@@ -25,10 +25,10 @@ This document provides general background and information about Claude Code to h
 
 ## Installation
 
-Claude Code requires Node.js 18+ and is available via npm:
+Claude Code requires Node.js 18+ and [is available via npm](https://code.claude.com/docs/en/setup#npm):
 
 ```bash
-npm install -g @anthropics/claude-code
+npm install -g @anthropic-ai/claude-code
 ```
 
 Verify installation:


### PR DESCRIPTION
The original command installed `anthropics/claude-code`, this gave me a 404 error. The site https://code.claude.com/docs/en/setup#npm provides the link as `anthropic-ai/claude-code`, which seemed to work.  

(There are some testing caveats, as in my final installation I installed via Homebrew for reasons unrelated to the above. But the 404 error was pretty clearcut.)

Note the claude site recommends Homebrew for the installation, so that's what I ended up doing. I didn't suggest change that in this pull request because I'm not sure of the implications, but thought I'd let you know.