### PR TITLE
Fix missing # of section links in the lesson index

### DIFF
--- a/docs/lesson/contributing-to-obo-ontologies.md
+++ b/docs/lesson/contributing-to-obo-ontologies.md
@@ -26,7 +26,7 @@ Participants will need to have access to the following resources and tools prior
   - [Branch vs Fork](#branch)
   - [How to create GitHub Issues](#issues)
 - [Understand basic Open Source etiquette](#etiquette)
-- [Reading READMEs](readme)
+- [Reading READMEs](#readme)
 - [Understand basics of ontology development workflows](#workflow)
   - [Browsing and Searching in Protege](#browsing)
   - [Add new terms to an ontology](#add)
@@ -35,8 +35,8 @@ Participants will need to have access to the following resources and tools prior
     - [The Class description view](#class-description)
 - [Use GitHub: make pull requests](#pr)
 - [Understand ontology design patterns](#pattern)
-- [Use templates: ROBOT, DOSDP](template) (_under development_)
-- [Basics of OWL](owl)
+- [Use templates: ROBOT, DOSDP](#template) (_under development_)
+- [Basics of OWL](#owl)
   - [Logic and debugging](#logic)
 
 ## Tutorials


### PR DESCRIPTION
Some links in the Learning objective index of the lesson "Contributing to OBO Ontologies" had broken links, giving a 404 error.

These should now be fixed from the addition of the missing # in front of the reference name.

Note that I haven't looked systematically for identical issues in other sections of the book. I saw this by chance while looking at that particular lesson.
